### PR TITLE
Started converting imports to paths.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,4 @@ dependencies:
   utf: ^0.9.0
 dev_dependencies:
   test: ^0.12.0
+  ng_bootstrap: any

--- a/test/foo/foo.scss
+++ b/test/foo/foo.scss
@@ -1,7 +1,9 @@
 @import "bar";
+@import "packages/bootstrap_sass/scss/variables";
 
 .foo {
   h1 {
     color: $col;
+    background-color: $gray;
   }
 }

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -25,7 +25,8 @@ main() {
       var outputId = new AssetId(testPackage, 'test/foo/foo.css');
       expect(barback.getAssetById(outputId).then((x) => x.readAsString()),
           completion('.foo h1 {\n'
-              '  color: red; }\n'
+              '  color: red;\n'
+              '  background-color: #55595c; }\n'
               ''));
     });
   });


### PR DESCRIPTION
Hi Luis,
I've started making changes to your library that would it work without generated packages. I still need to make replaceAllMapped function to work asynchronously. And make more tests. But I thought I could share with you what I have so far. I'm just wondering if you had a chance to work on this yourself? 
You also mentioned on g+ (https://plus.google.com/109268816341381365227/posts/YB9WRLtFYkA)
that you would try to use dart-sass library. Would be then any significant changes to sass_transformer package?